### PR TITLE
Update download location

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This piece of code enables [Apple QuickLook](http://en.wikipedia.org/wiki/Quick_
 * PBM (1-channel 1-bit) files
 
 # Download
-If you don't want to download the code, you can use the precompiled versions on the [Google-Code-Homepage](http://code.google.com/p/quicklook-pfm/downloads/list) or use the direct download of the current version below:
+If you don't want to download the code, you can use the precompiled versions on the [GitHub-Releases-Homepage](https://github.com/lnxbil/quicklook-pfm/releases) or use the direct download of the current version below:
 
-* [Version 1.1](http://code.google.com/p/quicklook-pfm/downloads/detail?name=quicklook-pfm-1.1.zip&can=2&q=)
+* [Version 1.1](https://github.com/lnxbil/quicklook-pfm/releases/download/1.1/quicklook-pfm-1.1.zip)
 
 #Installation
 Download the newest version, unpack the zip-file and copy the Quicklook-PFM into the following directory


### PR DESCRIPTION
As Google Code will be dead on [25 Jan](http://google-opensource.blogspot.com.au/2015/03/farewell-to-google-code.html), would you mind to move the [1.1 release files](https://code.google.com/p/quicklook-pfm/downloads/list) to somewhere else? (eq. [GitHub releases](https://github.com/blog/1547-release-your-software))

(Refs https://github.com/caskroom/homebrew-cask/issues/17075)
